### PR TITLE
Update README.md: Mention more requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,18 @@ With a focus on those example pages:
 
 ## Installation
 
-On your system, you need [git](https://git-scm.com/), [composer](https://getcomposer.org/), [sqlite](https://www.sqlite.org) and [make](https://www.gnu.org/software/make/) installed.
+System requirements:
+
+- [git](https://git-scm.com/)
+- [composer](https://getcomposer.org/)
+- [sqlite](https://www.sqlite.org) and the sqlite extension for your PHP version, e.g. php7.3-sqlite3.
+- [make](https://www.gnu.org/software/make/) installed.
 
 Then:
 
 1. Clone this repository
-1. Run `make clean` from the local clone
+1. Copy `.eng.example` as `.env`.
+1. Run `make clean` from the local clone. (causes error in freshly cloned project, but that's ok)
 1. Run `make install`
 1. Run `make run` to use the local PHP server
 


### PR DESCRIPTION
What I learned from installing this:

- needs `php*-sqlite*`, e.g. `php7.3-sqlite3`.
- needs `.env.example` copied to `.env`.
- `make clean` causes error, but I guess that's ok.

I could be wrong, I just want to share this before it gets lost.